### PR TITLE
Add some optional trailing commas to patterns

### DIFF
--- a/libmodernize/fixes/fix_filter.py
+++ b/libmodernize/fixes/fix_filter.py
@@ -15,7 +15,7 @@ class FixFilter(fixer_base.BaseFix):
         trailer< '('
             arglist< (
                 not(argument<any '=' any>) any ','
-                not(argument<any '=' any>) any
+                not(argument<any '=' any>) any [',']
             ) >
         ')' >
     >

--- a/libmodernize/fixes/fix_map.py
+++ b/libmodernize/fixes/fix_map.py
@@ -15,7 +15,7 @@ class FixMap(fixer_base.BaseFix):
         trailer< '('
             arglist< (
                 not(argument<any '=' any>) any ','
-                (not(argument<any '=' any>) any)+
+                (not(argument<any '=' any>) any)+ [',']
             ) >
         ')' >
     >


### PR DESCRIPTION
Minor fixes to patterns to allow for trailing commas in arguments.
