### PR TITLE
Simplify fix_metaclass

### DIFF
--- a/libmodernize/fixes/fix_metaclass.py
+++ b/libmodernize/fixes/fix_metaclass.py
@@ -209,27 +209,9 @@ class FixMetaclass(fixer_base.BaseFix):
         arguments = [metaclass]
 
         if arglist.children:
-            if len(arglist.children) == 1:
-                base = arglist.children[0].clone()
-                base.prefix = u' '
-            else:
-                # Unfortunately six.with_metaclass() only allows one base
-                # class, so we have to dynamically generate a base class if
-                # there is more than one.
-                bases = parenthesize(arglist.clone())
-                bases.prefix = u' '
-                base = Call(Name('type'), [
-                    String("'NewBase'"),
-                    Comma(),
-                    bases,
-                    Comma(),
-                    Node(
-                        syms.atom,
-                        [Leaf(token.LBRACE, u'{'), Leaf(token.RBRACE, u'}')],
-                        prefix=u' '
-                    )
-                ], prefix=u' ')
-            arguments.extend([Comma(), base])
+            bases = arglist.clone()
+            bases.prefix = u' '
+            arguments.extend([Comma(), bases])
 
         arglist.replace(Call(
             Name(u'six.with_metaclass', prefix=arglist.prefix),

--- a/tests/test_fix_metaclass.py
+++ b/tests/test_fix_metaclass.py
@@ -33,7 +33,7 @@ class Foo(Bar, Spam):
     __metaclass__ = Meta
 """, """\
 import six
-class Foo(six.with_metaclass(Meta, type('NewBase', (Bar, Spam), {}))):
+class Foo(six.with_metaclass(Meta, Bar, Spam)):
     pass
 """)
 
@@ -55,6 +55,7 @@ class Foo(six.with_metaclass(Meta, Bar)):
     b = 64
 """
 )
+
 
 def test_metaclass_no_base():
     check_on_input(*METACLASS_NO_BASE)


### PR DESCRIPTION
Update code for current features of six which simplify parameters for
six.with_metaclass().

Closes #47 
