### PR TITLE
Improve docs for fixers

### DIFF
--- a/docs/fixers.rst
+++ b/docs/fixers.rst
@@ -43,6 +43,8 @@ version of ``six`` is installed.
 
    Replaces all references to :func:`basestring` with :data:`six.string_types`.
 
+   .. versionadded:: 0.4
+
 .. 2to3fixer:: dict_six
 
    Fixes various methods on the ``dict`` type for getting all keys, values, or
@@ -119,6 +121,8 @@ version of ``six`` is installed.
    - ``ttk``
    - ``xmlrpclib``
 
+   .. versionadded:: 0.4
+
 .. 2to3fixer:: input_six
 
    Changes::
@@ -132,9 +136,13 @@ version of ``six`` is installed.
        eval(input(x))
        input(x)
 
+   .. versionadded:: 0.4
+
 .. 2to3fixer:: int_long_tuple
 
    Changes ``(int, long)`` or ``(long int)`` to :data:`six.integer_types`.
+
+   .. versionadded:: 0.4
 
 .. 2to3fixer:: map
 
@@ -227,10 +235,14 @@ Fixers with no dependencies
 
    Changes all calls to :func:`file <python2:file>` to :func:`open <python2:open>`.
 
+   .. versionadded:: 0.4
+
 .. 2to3fixer:: import
 
    Changes implicit relative imports to explicit relative imports and adds
    ``from __future__ import absolute_import``.
+
+   .. versionadded:: 0.4
 
 .. 2to3fixer:: next
 
@@ -267,5 +279,7 @@ to specify the ``all`` fixer, e.g.::
    When a call to :func:`open <python2:open>` is discovered, add ``from io import open`` at the top
    of the module so as to use :func:`io.open` instead. This fixer is opt-in because it
    changes what object is returned by a call to ``open()``.
+
+   .. versionadded:: 0.4
 
 .. _six project: http://pythonhosted.org/six


### PR DESCRIPTION
- Use `versionadded` directive on new fixers for the next release.
- Link to an explanation of writing fixers (#94)
