### PR TITLE
add fixer for `sorted()` and `list.sort`

### DIFF
--- a/libmodernize/fixes/fix_sorted.py
+++ b/libmodernize/fixes/fix_sorted.py
@@ -1,0 +1,101 @@
+import itertools
+from lib2to3 import fixer_base
+from lib2to3.fixer_util import Call, ArgList
+from lib2to3.fixer_util import Comma
+from lib2to3.fixer_util import KeywordArg
+from lib2to3.fixer_util import Name
+from lib2to3.fixer_util import Node
+from lib2to3.fixer_util import touch_import
+from lib2to3.pgen2 import token
+from lib2to3.pygram import python_symbols as symbols
+
+
+class FixSorted(fixer_base.BaseFix):
+    PATTERN = """
+              power< "sorted" trailer< "(" not arglist ")" > any* >
+              |
+              power< "sorted" trailer< "(" arglist< any "," func_args=any+ > ")" > any* >
+              |
+              power<any* trailer< any* >* trailer<"." "sort" > trailer<"(" arglist< func_args=any+ > ")"> any* >
+              |
+              power<any* trailer< any* >* trailer<"." "sort" > trailer<"(" func_arg=any+ ")"> any* >
+    """
+
+    def _transform_keyword(self, nodes, result):
+        '''transform second and later position argument into keyword argument'''
+        if not nodes:
+            return
+
+        if not isinstance(nodes, list):
+            nodes = [nodes]
+
+        parent = nodes[0].parent
+
+        # transform positional arguments
+        positional_args = list(
+            itertools.filterfalse(lambda arg: arg.type in (token.COMMA, symbols.argument), nodes)
+        )
+        template = ['cmp', 'key', 'reverse']
+        new_args = []
+        for arg, key in zip(positional_args, template):
+            arg_ = arg.clone()
+            arg_.prefix = ''
+
+            new_arg = KeywordArg(Name(key), arg_)
+            new_arg.prefix = arg.prefix
+            new_args.append(new_arg)
+
+            arg.remove()
+
+        for child in list(parent.children):
+            if child.type == token.COMMA and (
+                child.next_sibling is None or child.next_sibling.type == token.COMMA
+            ):
+                child.remove()
+
+        # update keyword argument list
+        keyword_args = list(filter(lambda arg: arg.type == symbols.argument, nodes))
+        keywords = [arg.children[0].value for arg in keyword_args]
+
+        assert parent.type == symbols.arglist
+        for arg in new_args:
+            if arg.children[0].value not in keywords:
+                if len(parent.children) > 0:
+                    parent.append_child(Comma())
+                parent.append_child(arg)
+
+        # update result mapping
+        return parent.children
+
+    def _transform_cmp(self, nodes, result):
+        '''transform argument `cmp` into `key`'''
+        arglist = list(filter(lambda arg: arg.type == symbols.argument, nodes))
+
+        cmp_node = None
+        key_node = None
+        for arg in arglist:
+            if arg.type == symbols.argument:
+                if arg.children[0].value == 'cmp':
+                    cmp_node = arg
+                if arg.children[0].value == 'key':
+                    key_node = arg
+
+        if cmp_node:
+            if key_node:
+                return  # Do nothing when it have both cmp and key argument
+
+            cmp_node.children[0].value = 'key'
+            cmp_node.children[2].replace(
+                Call(Name('cmp_to_key'), args=[cmp_node.children[2].clone()])
+            )
+            touch_import('functools', 'cmp_to_key', cmp_node)
+
+    def transform(self, node, result):
+        if result.get('func_arg'):
+            a = Node(symbols.arglist, [r.clone() for r in result['func_arg']])
+            result['func_arg'][0].replace(a)
+            result['func_args'] = a.children
+
+        if result.get('func_args'):
+            ret = self._transform_keyword(result['func_args'], result)
+            self._transform_cmp(ret, result)

--- a/libmodernize/fixes/fix_sorted.py
+++ b/libmodernize/fixes/fix_sorted.py
@@ -1,6 +1,5 @@
-import itertools
 from lib2to3 import fixer_base
-from lib2to3.fixer_util import Call, ArgList
+from lib2to3.fixer_util import Call
 from lib2to3.fixer_util import Comma
 from lib2to3.fixer_util import KeywordArg
 from lib2to3.fixer_util import Name
@@ -8,6 +7,11 @@ from lib2to3.fixer_util import Node
 from lib2to3.fixer_util import touch_import
 from lib2to3.pgen2 import token
 from lib2to3.pygram import python_symbols as symbols
+
+try:
+    from itertools import filterfalse
+except ImportError:
+    from itertools import ifilterfalse as filterfalse
 
 
 class FixSorted(fixer_base.BaseFix):
@@ -33,7 +37,7 @@ class FixSorted(fixer_base.BaseFix):
 
         # transform positional arguments
         positional_args = list(
-            itertools.filterfalse(lambda arg: arg.type in (token.COMMA, symbols.argument), nodes)
+            filterfalse(lambda arg: arg.type in (token.COMMA, symbols.argument), nodes)
         )
         template = ['cmp', 'key', 'reverse']
         new_args = []

--- a/tests/test_fix_sorted.py
+++ b/tests/test_fix_sorted.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import
+
+from utils import check_on_input
+
+
+# py2, sorted(iterable[, cmp[, key[, reverse]]])
+SORTED_CALL = ("""\
+sorted(a_list, cmp_function)
+sorted(a_list, lambda x,y: x-y)
+sorted(a_list, key=key_function, reverse=True)
+""", """\
+from __future__ import absolute_import
+from functools import cmp_to_key
+sorted(a_list, key=cmp_to_key(cmp_function))
+sorted(a_list, key=cmp_to_key(lambda x,y: x-y))
+sorted(a_list, key=key_function, reverse=True)
+""")
+
+
+LIST_SORT_CALL = ("""\
+a_list.sort(cmp_function)
+a_list.sort(lambda x,y: x-y)
+a_list.sort(key=key_function, reverse=True)
+""", """\
+from __future__ import absolute_import
+from functools import cmp_to_key
+a_list.sorted(key=cmp_to_key(cmp_function))
+a_list.sorted(key=cmp_to_key(lambda x,y: x-y))
+a_list.sorted(key=key_function, reverse=True)
+""")
+
+
+def test_sorted_call():
+    check_on_input(*SORTED_CALL)
+
+def test_list_sort_call():
+    check_on_input(*LIST_SORT_CALL)

--- a/tests/test_fix_sorted.py
+++ b/tests/test_fix_sorted.py
@@ -24,9 +24,9 @@ a_list.sort(key=key_function, reverse=True)
 """, """\
 from __future__ import absolute_import
 from functools import cmp_to_key
-a_list.sorted(key=cmp_to_key(cmp_function))
-a_list.sorted(key=cmp_to_key(lambda x,y: x-y))
-a_list.sorted(key=key_function, reverse=True)
+a_list.sort(key=cmp_to_key(cmp_function))
+a_list.sort(key=cmp_to_key(lambda x,y: x-y))
+a_list.sort(key=key_function, reverse=True)
 """)
 
 


### PR DESCRIPTION
In python3, `sorted()` and `list.sort()` only accept keyword-only
argument and drop support of the `cmp` flag.  This fixer helps you
overcome all these trap by wrapping `functools.cmp_to_key` to original
`cmp` argument and transforming it to `key` argument. See
https://docs.python.org/3.8/library/stdtypes.html#list.sort