### PR TITLE
node shouldn't be needed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,11 +25,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Set Up Node for prettier
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14.x
-
       - name: Install
         run: |
           pip install tox


### PR DESCRIPTION
pre-commit will bootstrap a node environment if there isn't one there