### PR TITLE
upgrade all docs deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,17 @@ requires = ["fissix"]
 requires-python = "~=3.6"
 
 [tool.flit.metadata.requires-extra]
-docs = ["sphinx~=3.2"]
+docs = [
+  "alabaster~=0.7.12",
+  "commonmark~=0.9.1",
+  "docutils~=0.16.0",
+  "mock~=4.0",
+  "pillow~=7.2",
+  "readthedocs-sphinx-ext~=2.1",
+  "recommonmark~=0.6.0",
+  "sphinx~=3.2",
+  "sphinx-rtd-theme~=0.5.0",
+]
 test = ["pytest", "pytest-cov", "coverage>=5.3"]
 
 [tool.flit.scripts]


### PR DESCRIPTION
based on the default packages that rtd installs ```/home/docs/checkouts/readthedocs.org/user_builds/ldaptor/envs/185/bin/python -m pip install --upgrade --no-cache-dir --use-feature 2020-resolver setuptools==41.0.1 docutils==0.14 mock==1.0.1 pillow==5.4.1 alabaster>=0.7,<0.8,!=0.7.5 commonmark==0.8.1 recommonmark==0.5.0 sphinx<2 sphinx-rtd-theme<0.5 readthedocs-sphinx-ext<1.1```