### PR TITLE
docs: fix simple typo, wich -> which

### DIFF
--- a/modernize/fixes/fix_itertools_six.py
+++ b/modernize/fixes/fix_itertools_six.py
@@ -44,7 +44,7 @@ class FixItertoolsSix(fixer_base.BaseFix):
             # Remove the 'itertools'
             prefix = it.prefix
             it.remove()
-            # Replace the node wich contains ('.', 'function') with the
+            # Replace the node which contains ('.', 'function') with the
             # function (to be consistant with the second part of the pattern)
             dot.remove()
             func.parent.replace(func)


### PR DESCRIPTION
There is a small typo in modernize/fixes/fix_itertools_six.py.

Should read `which` rather than `wich`.

