### PR TITLE
GitHub Action: Add Python 3.10 and remove 3.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [macOS-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,13 +47,7 @@ jobs:
       - name: tox
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: tox -e py,lint,release
-
-      - uses: codecov/codecov-action@v2
-        with:
-          name: ${{ matrix.os }}_${{ matrix.python-version}}
-          fail_ci_if_error: true
-          verbose: true
+        run: tox -e py,lint,release # coveralls
 
       - name: upload dist
         uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set Up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -31,7 +31,7 @@ jobs:
           echo "::set-output name=dir::$(pip cache dir)"
 
       - name: pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key:
@@ -47,10 +47,10 @@ jobs:
       - name: tox
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: tox -e py,lint,coveralls,release
+        run: tox -e py,lint,release  # coveralls
 
       - name: upload dist
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.os }}_${{ matrix.python-version}}_dist
           path: dist
@@ -61,7 +61,7 @@ jobs:
     needs: [tox]
     steps:
       - name: Download dists for PyPI
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ubuntu-latest_3.8_dist
           path: dist

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [macOS-latest, ubuntu-latest, windows-latest]
 
     steps:
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set Up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,13 @@ jobs:
       - name: tox
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: tox -e py,lint,release # coveralls
+        run: tox -e py,lint,release
+
+      - uses: codecov/codecov-action@v2
+        with:
+          name: ${{ matrix.os }}_${{ matrix.python-version}}
+          fail_ci_if_error: true
+          verbose: true
 
       - name: upload dist
         uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       - name: tox
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: tox -e py,lint,release  # coveralls
+        run: tox -e py,lint,release # coveralls
 
       - name: upload dist
         uses: actions/upload-artifact@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,34 +1,34 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.34.0
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
         args: ["--py37-plus"]
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.1.0
     hooks:
       - id: black
         args: ["--target-version", "py37"]
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.9.0
+    rev: v1.10.0
     hooks:
       - id: python-check-blanket-noqa
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-merge-conflict
       - id: check-toml
@@ -36,13 +36,13 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.7.1
+    rev: v3.0.0-alpha.6
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]
 
   - repo: https://github.com/myint/autoflake
-    rev: v1.4
+    rev: v2.0.2
     hooks:
       - id: autoflake
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,13 @@ repos:
     rev: v2.34.0
     hooks:
       - id: pyupgrade
-        args: ["--py36-plus"]
+        args: ["--py37-plus"]
 
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:
       - id: black
-        args: ["--target-version", "py36"]
+        args: ["--target-version", "py37"]
 
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,34 +1,34 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.4
+    rev: v2.34.0
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
         args: ["--target-version", "py36"]
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.2
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.7.0
+    rev: 5.10.1
     hooks:
       - id: isort
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.7.0
+    rev: v1.9.0
     hooks:
       - id: python-check-blanket-noqa
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.3.0
     hooks:
       - id: check-merge-conflict
       - id: check-toml
@@ -36,7 +36,7 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.2.1
+    rev: v2.7.1
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]

--- a/README.rst
+++ b/README.rst
@@ -6,9 +6,6 @@
       |_|_|_\___/\__,_\___|_| |_||_|_/__\___|
 
 
-.. image:: https://img.shields.io/coveralls/github/PyCQA/modernize?label=coveralls&logo=coveralls
-    :alt: Coveralls
-    :target: https://coveralls.io/github/PyCQA/modernize
 .. image:: https://img.shields.io/readthedocs/modernize?logo=read-the-docs
     :alt: Read the Docs
     :target: https://modernize.readthedocs.io/en/latest/

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,9 @@
       |_|_|_\___/\__,_\___|_| |_||_|_/__\___|
 
 
+.. image:: https://img.shields.io/coveralls/github/PyCQA/modernize?label=coveralls&logo=coveralls
+    :alt: Coveralls
+    :target: https://coveralls.io/github/PyCQA/modernize
 .. image:: https://img.shields.io/readthedocs/modernize?logo=read-the-docs
     :alt: Read the Docs
     :target: https://modernize.readthedocs.io/en/latest/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,13 +11,10 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-from __future__ import generator_stop
 
 # -- General configuration ------------------------------------------------
-
 # If your documentation needs a minimal Sphinx version, state it here.
 # needs_sphinx = '1.0'
-
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.

--- a/modernize/__init__.py
+++ b/modernize/__init__.py
@@ -2,6 +2,5 @@
 A hack on top of fissix (lib2to3 fork) for modernizing code for hybrid codebases.
 """
 
-from __future__ import generator_stop
 
 __version__ = "0.9rc1.dev0"

--- a/modernize/__main__.py
+++ b/modernize/__main__.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 import sys
 
 from .main import main

--- a/modernize/fixes/__init__.py
+++ b/modernize/fixes/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 fissix_fix_names = {
     "fissix.fixes.fix_apply",
     "fissix.fixes.fix_except",

--- a/modernize/fixes/fix_basestring.py
+++ b/modernize/fixes/fix_basestring.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from fissix import fixer_base, fixer_util
 
 

--- a/modernize/fixes/fix_classic_division.py
+++ b/modernize/fixes/fix_classic_division.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from fissix import fixer_base, pytree
 from fissix.pgen2 import token
 

--- a/modernize/fixes/fix_dict_six.py
+++ b/modernize/fixes/fix_dict_six.py
@@ -2,7 +2,6 @@
 Fixer for iterkeys() -> six.iterkeys(), and similarly for iteritems and itervalues.
 """
 
-from __future__ import generator_stop
 
 # Local imports
 from fissix import fixer_util, pytree

--- a/modernize/fixes/fix_file.py
+++ b/modernize/fixes/fix_file.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from fissix import fixer_base
 from fissix.fixer_util import Name
 

--- a/modernize/fixes/fix_file.py
+++ b/modernize/fixes/fix_file.py
@@ -3,7 +3,6 @@ from fissix.fixer_util import Name
 
 
 class FixFile(fixer_base.BaseFix):
-
     BM_compatible = True
     order = "pre"
 

--- a/modernize/fixes/fix_filter.py
+++ b/modernize/fixes/fix_filter.py
@@ -1,7 +1,6 @@
 # Copyright 2008 Armin Ronacher.
 # Licensed to PSF under a Contributor Agreement.
 
-from __future__ import generator_stop
 
 from fissix import fixer_util
 from fissix.fixes import fix_filter

--- a/modernize/fixes/fix_filter.py
+++ b/modernize/fixes/fix_filter.py
@@ -9,7 +9,6 @@ from .. import utils
 
 
 class FixFilter(fix_filter.FixFilter):
-
     skip_on = "six.moves.filter"
 
     def transform(self, node, results):

--- a/modernize/fixes/fix_import.py
+++ b/modernize/fixes/fix_import.py
@@ -5,7 +5,6 @@ from .. import utils
 
 
 class FixImport(fix_import.FixImport):
-
     # Make sure this runs before any other fixer to guarantee that any other
     # added absolute_import doesn't block this fixer's execution.
     run_order = 1

--- a/modernize/fixes/fix_import.py
+++ b/modernize/fixes/fix_import.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from fissix.fixer_util import syms
 from fissix.fixes import fix_import
 

--- a/modernize/fixes/fix_imports_six.py
+++ b/modernize/fixes/fix_imports_six.py
@@ -2,7 +2,6 @@ from fissix.fixes import fix_imports
 
 
 class FixImportsSix(fix_imports.FixImports):
-
     mapping = {
         "__builtin__": "six.moves.builtins",
         "_winreg": "six.moves.winreg",

--- a/modernize/fixes/fix_imports_six.py
+++ b/modernize/fixes/fix_imports_six.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from fissix.fixes import fix_imports
 
 

--- a/modernize/fixes/fix_input_six.py
+++ b/modernize/fixes/fix_input_six.py
@@ -8,7 +8,6 @@
 #     Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
 #     2011, 2012, 2013, 2014 Python Software Foundation. All rights reserved.
 
-from __future__ import generator_stop
 
 from fissix import fixer_base, fixer_util
 from fissix.fixer_util import Call, Name

--- a/modernize/fixes/fix_input_six.py
+++ b/modernize/fixes/fix_input_six.py
@@ -14,7 +14,6 @@ from fissix.fixer_util import Call, Name
 
 
 class FixInputSix(fixer_base.ConditionalFix):
-
     BM_compatible = True
     order = "pre"
     skip_on = "six.moves.input"

--- a/modernize/fixes/fix_int_long_tuple.py
+++ b/modernize/fixes/fix_int_long_tuple.py
@@ -2,7 +2,6 @@ from fissix import fixer_base, fixer_util
 
 
 class FixIntLongTuple(fixer_base.BaseFix):
-
     run_order = 4  # Must run before fix_long.
 
     PATTERN = """

--- a/modernize/fixes/fix_int_long_tuple.py
+++ b/modernize/fixes/fix_int_long_tuple.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from fissix import fixer_base, fixer_util
 
 

--- a/modernize/fixes/fix_itertools_imports_six.py
+++ b/modernize/fixes/fix_itertools_imports_six.py
@@ -1,6 +1,5 @@
 """ Fixer for imports of itertools.(imap|ifilter|izip|ifilterfalse) """
 
-from __future__ import generator_stop
 
 # Local imports
 from fissix import fixer_base, fixer_util

--- a/modernize/fixes/fix_itertools_six.py
+++ b/modernize/fixes/fix_itertools_six.py
@@ -5,6 +5,8 @@
     If itertools is imported as something else (ie: import itertools as it;
     it.izip(spam, eggs)) method calls will not get fixed.
     """
+
+
 # This is a derived work of Lib/lib2to3/fixes/fix_itertools_import.py. That file
 # is under the copyright of the Python Software Foundation and licensed
 # under the Python Software Foundation License 2.
@@ -13,8 +15,6 @@
 #
 #     Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
 #     2011, 2012, 2013 Python Software Foundation. All rights reserved.
-from __future__ import generator_stop
-
 # Local imports
 from fissix import fixer_base, fixer_util
 from fissix.fixer_util import Name

--- a/modernize/fixes/fix_map.py
+++ b/modernize/fixes/fix_map.py
@@ -9,7 +9,6 @@ from .. import utils
 
 
 class FixMap(fix_map.FixMap):
-
     skip_on = "six.moves.map"
 
     def transform(self, node, results):

--- a/modernize/fixes/fix_map.py
+++ b/modernize/fixes/fix_map.py
@@ -1,7 +1,6 @@
 # Copyright 2008 Armin Ronacher.
 # Licensed to PSF under a Contributor Agreement.
 
-from __future__ import generator_stop
 
 from fissix import fixer_util
 from fissix.fixes import fix_map

--- a/modernize/fixes/fix_metaclass.py
+++ b/modernize/fixes/fix_metaclass.py
@@ -14,6 +14,8 @@
    This fixer also tries very hard to keep original indenting and spacing
    in all those corner cases.
 """
+
+
 # This is a derived work of Lib/lib2to3/fixes/fix_metaclass.py. That file
 # is under the copyright of the Python Software Foundation and licensed
 # under the Python Software Foundation License 2.
@@ -22,8 +24,6 @@
 #
 #     Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
 #     2011, 2012, 2013 Python Software Foundation. All rights reserved.
-from __future__ import generator_stop
-
 # Local imports
 from fissix import fixer_base, fixer_util
 from fissix.fixer_util import Call, Comma, Leaf, Name, Node, syms

--- a/modernize/fixes/fix_next.py
+++ b/modernize/fixes/fix_next.py
@@ -1,6 +1,5 @@
 """Fixer for it.next() -> next(it)"""
 
-from __future__ import generator_stop
 
 # Local imports
 from fissix import fixer_base

--- a/modernize/fixes/fix_open.py
+++ b/modernize/fixes/fix_open.py
@@ -2,7 +2,6 @@ from fissix import fixer_base, fixer_util
 
 
 class FixOpen(fixer_base.BaseFix):
-
     BM_compatible = True
     # Fixers don't directly stack, so make sure the 'file' case is covered.
     PATTERN = """

--- a/modernize/fixes/fix_open.py
+++ b/modernize/fixes/fix_open.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from fissix import fixer_base, fixer_util
 
 

--- a/modernize/fixes/fix_print.py
+++ b/modernize/fixes/fix_print.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from fissix.fixes import fix_print
 
 from .. import utils

--- a/modernize/fixes/fix_raise.py
+++ b/modernize/fixes/fix_raise.py
@@ -17,9 +17,9 @@ CAVEATS:
    any client code would have to be changed as well, we don't automate
    this.
 """
-# Author: Collin Winter, Armin Ronacher
-from __future__ import generator_stop
 
+
+# Author: Collin Winter, Armin Ronacher
 from fissix.fixes import fix_raise
 
 

--- a/modernize/fixes/fix_raise_six.py
+++ b/modernize/fixes/fix_raise_six.py
@@ -12,7 +12,6 @@ from fissix.fixer_util import Call, Comma, Name
 
 
 class FixRaiseSix(fixer_base.BaseFix):
-
     BM_compatible = True
     PATTERN = """
     raise_stmt< 'raise' exc=any ',' val=any ',' tb=any >

--- a/modernize/fixes/fix_raise_six.py
+++ b/modernize/fixes/fix_raise_six.py
@@ -3,9 +3,9 @@
 raise E, V, T -> six.reraise(E, V, T)
 
 """
-# Author : Markus Unterwaditzer
-from __future__ import generator_stop
 
+
+# Author : Markus Unterwaditzer
 # Local imports
 from fissix import fixer_base, fixer_util
 from fissix.fixer_util import Call, Comma, Name

--- a/modernize/fixes/fix_unichr.py
+++ b/modernize/fixes/fix_unichr.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from fissix import fixer_base, fixer_util
 from fissix.fixer_util import is_probably_builtin
 

--- a/modernize/fixes/fix_unicode.py
+++ b/modernize/fixes/fix_unicode.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 import re
 
 from fissix import fixer_base, fixer_util

--- a/modernize/fixes/fix_unicode_future.py
+++ b/modernize/fixes/fix_unicode_future.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from fissix.fixes import fix_unicode
 
 from .. import utils

--- a/modernize/fixes/fix_unicode_type.py
+++ b/modernize/fixes/fix_unicode_type.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from fissix import fixer_base, fixer_util
 
 

--- a/modernize/fixes/fix_urllib_six.py
+++ b/modernize/fixes/fix_urllib_six.py
@@ -2,6 +2,8 @@
    This is a copy of Lib/lib2to3/fixes/fix_urllib.py, but modified to point to the
    six.moves locations for new libraries instead of the Python 3 locations.
 """
+
+
 # This is a derived work of Lib/lib2to3/fixes/fix_urllib.py. That file
 # is under the copyright of the Python Software Foundation and licensed
 # under the Python Software Foundation License 2.
@@ -10,8 +12,6 @@
 #
 #     Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
 #     2011, 2012, 2013 Python Software Foundation. All rights reserved.
-from __future__ import generator_stop
-
 from fissix.fixer_util import (
     Comma,
     FromImport,

--- a/modernize/fixes/fix_xrange_six.py
+++ b/modernize/fixes/fix_xrange_six.py
@@ -7,7 +7,6 @@ from fissix.fixes import fix_xrange
 
 
 class FixXrangeSix(fixer_base.ConditionalFix, fix_xrange.FixXrange):
-
     skip_on = "six.moves.range"
 
     def transform(self, node, results):

--- a/modernize/fixes/fix_xrange_six.py
+++ b/modernize/fixes/fix_xrange_six.py
@@ -1,7 +1,6 @@
 # Copyright 2008 Armin Ronacher.
 # Licensed to PSF under a Contributor Agreement.
 
-from __future__ import generator_stop
 
 from fissix import fixer_base, fixer_util
 from fissix.fixes import fix_xrange

--- a/modernize/fixes/fix_zip.py
+++ b/modernize/fixes/fix_zip.py
@@ -7,7 +7,6 @@ from fissix.fixes import fix_zip
 
 
 class FixZip(fix_zip.FixZip):
-
     skip_on = "six.moves.zip"
 
     def transform(self, node, results):

--- a/modernize/fixes/fix_zip.py
+++ b/modernize/fixes/fix_zip.py
@@ -1,7 +1,6 @@
 # Copyright 2008 Armin Ronacher.
 # Licensed to PSF under a Contributor Agreement.
 
-from __future__ import generator_stop
 
 from fissix import fixer_util
 from fissix.fixes import fix_zip

--- a/modernize/main.py
+++ b/modernize/main.py
@@ -5,7 +5,6 @@ Python           _              _
   |_|_|_\\___/\\__,_\\___|_| |_||_|_/__\\___|\
 """
 
-from __future__ import generator_stop
 
 import logging
 import optparse

--- a/modernize/utils.py
+++ b/modernize/utils.py
@@ -49,7 +49,6 @@ def _check_future_import(node):
 
 
 def add_future(node, symbol):
-
     root = fixer_util.find_root(node)
 
     for idx, node in enumerate(root.children):

--- a/modernize/utils.py
+++ b/modernize/utils.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from fissix import fixer_util
 from fissix.pgen2 import token
 from fissix.pygram import python_symbols as syms

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ docs = [
   "alabaster~=0.7.12",
   "commonmark~=0.9.1",
   "docutils~=0.16.0",
-  "Jinja2<=3.1",
+  "Jinja2<3.1",
   "mock~=4.0",
   "pillow~=7.2",
   "readthedocs-sphinx-ext~=2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 description-file = "README.rst"
 requires = ["fissix"]
@@ -80,7 +81,7 @@ legacy_tox_ini = """
 
 [tox]
 envlist =
-    py{37,38,39,310},lint
+    py{37,38,39,310,311},lint
 minversion=3.20.1
 isolated_build=true
 requires=

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,10 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
 ]
 description-file = "README.rst"
 requires = ["fissix"]
@@ -79,7 +79,7 @@ legacy_tox_ini = """
 
 [tox]
 envlist =
-    py{36,37,38,39},lint
+    py{37,38,39,310},lint
 minversion=3.20.1
 isolated_build=true
 requires=

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,13 @@ wheel_build_env = build
 # empty environment to build universal wheel once per tox invocation
 # https://github.com/ionelmc/tox-wheel#build-configuration
 
+[testenv:coveralls]
+passenv = GITHUB_*
+deps =
+  coveralls
+  coverage>=5.3
+commands = coveralls
+
 [testenv:lint]
 deps = pre-commit
 commands = pre-commit run --all-files --show-diff-on-failure {posargs}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,18 +98,10 @@ wheel_build_env = build
 # empty environment to build universal wheel once per tox invocation
 # https://github.com/ionelmc/tox-wheel#build-configuration
 
-[testenv:coveralls]
-passenv = GITHUB_*
-deps =
-  coveralls
-  coverage>=5.3
-commands = coveralls
-
 [testenv:lint]
 deps = pre-commit
 commands = pre-commit run --all-files --show-diff-on-failure {posargs}
 skip_install = true
-
 
 [testenv:release]
 deps = pep517

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ docs = [
   "alabaster~=0.7.12",
   "commonmark~=0.9.1",
   "docutils~=0.16.0",
+  "Jinja2<=3.1",
   "mock~=4.0",
   "pillow~=7.2",
   "readthedocs-sphinx-ext~=2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 description-file = "README.rst"
 requires = ["fissix"]
-requires-python = "~=3.6"
+requires-python = "~=3.7"
 
 [tool.flit.metadata.requires-extra]
 docs = [
@@ -43,7 +43,7 @@ python-modernize = "modernize.main:main"
 
 [tool.isort]
 profile = "black"
-add_imports=["from __future__ import generator_stop"]
+remove_imports=["from __future__ import generator_stop"]
 
 [tool.pytest.ini_options]
 addopts = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,5 +5,5 @@ tag-format = v{version}
 [flake8]
 disable-noqa = True
 max-line-length = 88
-extend-ignore =
-   E203,  # whitespace before : is not PEP8 compliant (& conflicts with black)
+extend-ignore = E203
+# E203 whitespace before : is not PEP8 compliant (& conflicts with black)

--- a/tests/test_fix_basestring.py
+++ b/tests/test_fix_basestring.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from utils import check_on_input
 
 BASESTRING = (

--- a/tests/test_fix_classic_division.py
+++ b/tests/test_fix_classic_division.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from utils import check_on_input
 
 CLASSIC_DIVISION = (

--- a/tests/test_fix_dict_six.py
+++ b/tests/test_fix_dict_six.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from utils import check_on_input
 
 TYPES = "keys", "items", "values"

--- a/tests/test_fix_file.py
+++ b/tests/test_fix_file.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from utils import check_on_input
 
 FILE_CALL = (

--- a/tests/test_fix_filter.py
+++ b/tests/test_fix_filter.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from utils import check_on_input
 
 FILTER_CALL = (

--- a/tests/test_fix_import.py
+++ b/tests/test_fix_import.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from utils import check_on_input
 
 NO_IMPORTS = (

--- a/tests/test_fix_imports_six.py
+++ b/tests/test_fix_imports_six.py
@@ -2,7 +2,7 @@ import sys
 import unittest
 
 try:
-    from six.moves import tkinter
+    import tkinter
 except ImportError:
     tkinter = None
 

--- a/tests/test_fix_imports_six.py
+++ b/tests/test_fix_imports_six.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 import sys
 import unittest
 

--- a/tests/test_fix_input_six.py
+++ b/tests/test_fix_input_six.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from utils import check_on_input
 
 INPUT = (

--- a/tests/test_fix_int_long_tuple.py
+++ b/tests/test_fix_int_long_tuple.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from utils import check_on_input
 
 INT_LONG_ISINSTANCE = (

--- a/tests/test_fix_itertools_imports_six.py
+++ b/tests/test_fix_itertools_imports_six.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from utils import check_on_input
 
 IZIP_AND_CHAIN_REFERENCE = (

--- a/tests/test_fix_map.py
+++ b/tests/test_fix_map.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from utils import check_on_input
 
 MAP_1_ARG = (

--- a/tests/test_fix_metaclass.py
+++ b/tests/test_fix_metaclass.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from utils import check_on_input
 
 METACLASS_NO_BASE = (

--- a/tests/test_fix_next.py
+++ b/tests/test_fix_next.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from utils import check_on_input
 
 NEXT_METHOD = (

--- a/tests/test_fix_open.py
+++ b/tests/test_fix_open.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from utils import check_on_input
 
 OPEN = (

--- a/tests/test_fix_print.py
+++ b/tests/test_fix_print.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from utils import check_on_input
 
 PRINT_BARE = (

--- a/tests/test_fix_raise.py
+++ b/tests/test_fix_raise.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from utils import check_on_input
 
 RAISE = (

--- a/tests/test_fix_unichr_type.py
+++ b/tests/test_fix_unichr_type.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from utils import check_on_input
 
 UNICHR_METHOD_REF = (

--- a/tests/test_fix_unicode.py
+++ b/tests/test_fix_unicode.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from utils import check_on_input
 
 UNICODE_LITERALS = """\

--- a/tests/test_fix_unicode_type.py
+++ b/tests/test_fix_unicode_type.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from utils import check_on_input
 
 UNICODE_TYPE_REF = (

--- a/tests/test_fix_urllib_six.py
+++ b/tests/test_fix_urllib_six.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from utils import check_on_input
 
 URLLIB_MODULE_REFERENCE = (

--- a/tests/test_fix_xrange_six.py
+++ b/tests/test_fix_xrange_six.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from utils import check_on_input
 
 RANGE = (

--- a/tests/test_fix_zip.py
+++ b/tests/test_fix_zip.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from utils import check_on_input
 
 ZIP_CALL_NO_ARGS = (

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from fissix import refactor
 
 from modernize import fixes

--- a/tests/test_future_behaviour.py
+++ b/tests/test_future_behaviour.py
@@ -65,7 +65,7 @@ def _check_on_input(file_content, extra_flags=[]):
     try:
         tmpdirname = tempfile.mkdtemp()
         test_input_name = os.path.join(tmpdirname, "input.py")
-        with open(test_input_name, "wt") as input:
+        with open(test_input_name, "w") as input:
             input.write(file_content)
         modernize_main(extra_flags + ["-w", test_input_name])
         _check_for_multiple_futures(test_input_name, file_content)
@@ -93,7 +93,7 @@ def test_two_files_on_single_run():
             os.path.join(tmpdirname, f"input_{idx}.py") for idx in range(0, 3)
         ]
         for input_name in input_names:
-            with open(input_name, "wt") as input:
+            with open(input_name, "w") as input:
                 input.write(TWO_PRINTS_CONTENT)
         modernize_main(["-w"] + input_names)
         for input_name in input_names:

--- a/tests/test_future_behaviour.py
+++ b/tests/test_future_behaviour.py
@@ -1,6 +1,5 @@
 # Tests for problem with multiple futures added to single file
 
-from __future__ import generator_stop
 
 import os
 import shutil

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 import contextlib
 import io
 

--- a/tests/test_raise_six.py
+++ b/tests/test_raise_six.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from utils import check_on_input
 
 RAISE_TRACEBACK = (

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,7 +21,7 @@ def check_on_input(
     tmpdirname = tempfile.mkdtemp()
     try:
         test_input_name = os.path.join(tmpdirname, "input.py")
-        with open(test_input_name, "wt") as input_file:
+        with open(test_input_name, "w") as input_file:
             input_file.write(input_content)
 
         def _check(this_input_content, which_check, check_return_code=True):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 import os.path
 import shutil
 import tempfile


### PR DESCRIPTION
https://devguide.python.org/#status-of-python-branches vs.
https://devguide.python.org/devcycle/#end-of-life-branches

All tests are green but `.github/workflows/main.yml` line 50 needs some attention from someone who knows `coveralls`.
* ~@graingert  I took your changes from #253~  That did not work out.  Reverted.

`generator_stop` is history in Python >= 3.7.  https://docs.python.org/3/library/__future__.html

@takluyver @graingert Your reviews, please.